### PR TITLE
make mixin client side only

### DIFF
--- a/common/src/main/resources/findme-common.mixins.json
+++ b/common/src/main/resources/findme-common.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "package": "com.buuz135.findme.mixin",
   "compatibilityLevel": "JAVA_17",
-  "mixins": [
+  "client": [
     "MixinSlotRenderer",
     "ParticleEngineAccessor"
   ],


### PR DESCRIPTION
```log
[20Sep2025 05:03:26.614] [main/ERROR] [net.minecraftforge.fml.loading.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/particle/ParticleEngine for invalid dist DEDICATED_SERVER
[20Sep2025 05:03:26.614] [main/WARN] [mixin/]: Error loading class: net/minecraft/client/particle/ParticleEngine (java.lang.RuntimeException: Attempted to load class net/minecraft/client/particle/ParticleEngine for invalid dist DEDICATED_SERVER)
[20Sep2025 05:03:26.614] [main/WARN] [mixin/]: @Mixin target net.minecraft.client.particle.ParticleEngine was not found findme-common.mixins.json:ParticleEngineAccessor
[20Sep2025 05:03:26.612] [main/ERROR] [net.minecraftforge.fml.loading.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/AbstractContainerScreen for invalid dist DEDICATED_SERVER
[20Sep2025 05:03:26.613] [main/WARN] [mixin/]: Error loading class: net/minecraft/client/gui/screens/inventory/AbstractContainerScreen (java.lang.RuntimeException: Attempted to load class net/minecraft/client/gui/screens/inventory/AbstractContainerScreen for invalid dist DEDICATED_SERVER)
[20Sep2025 05:03:26.613] [main/WARN] [mixin/]: @Mixin target net.minecraft.client.gui.screens.inventory.AbstractContainerScreen was not found findme-common.mixins.json:MixinSlotRenderer
```

fix above warnings when loaded on server